### PR TITLE
Go format and vet checks as part of build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
+APIDGOPACKAGES = $(shell go list ./... | grep -v vendor)
+APIDGOFILES = $(shell git ls-files | grep '.go$$' | grep -v vendor)
+GOFMTCOUNT = $(shell gofmt -l $(APIDGOFILES) | wc -l)
 fresh: update build
-build:
+build: fmtcheck
 	@(go build  -o helper/buildhelper helper/buildhelper.go;)
 	@(go test github.com/apid/apid/helper;)
 	@(./helper/buildhelper ./glide.lock 2>builderr 1>buildapid; rm helper/buildhelper;)
@@ -7,3 +10,6 @@ build:
 	@(chmod +x ./buildapid; echo "building apid..."; ./buildapid; rm builderr buildapid)
 update:
 	@(rm glide.lock; glide update -v)
+fmtcheck:
+	go vet $(APIDGOPACKAGES)
+	@(if [ $(GOFMTCOUNT) -gt 0 ]; then echo 'Run "go fmt $$(glide novendor)" on your go source code'; exit 1; else echo "Go source format look good"; fi)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # apid
 
+[![Build Status](https://travis-ci.org/apid/apid.svg)](https://travis-ci.org/apid/apid) [![Go Report Card](https://goreportcard.com/badge/github.com/apid/apid)](https://goreportcard.com/report/github.com/apid/apid)
+
 apid is a container for publishing APIs that provides core services to its plugins including configuration, 
 API publishing, data access, and a local pub/sub event system.
 

--- a/load-test/mock_server/main.go
+++ b/load-test/mock_server/main.go
@@ -14,9 +14,10 @@
 package main
 
 import (
-	"net/http"
 	"github.com/apid/apid/load-test/mock_server/mock_test_server"
+	"net/http"
 )
+
 func main() {
 	testServer := &mock_test_server.MockAuthServer{}
 	testServer.Start()

--- a/version/version.go
+++ b/version/version.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 package version
+
 const (
 	VERSION_NUMBER = "0.0.26"
 )


### PR DESCRIPTION
Added make target `fmtcheck` to perform `go vet` & `gofmt` checks on `apid` Go packages/source. Build fails if contributor don't take care of `go fmt` and/or `go vet`

As part of adding this check I end up had to update `main.go` and `version.go` to confirm to `gofmt` statndard.

Also included travis build status badge (by default this pulls for master branch I believe).